### PR TITLE
Apply clang-format to remove extra whitespace

### DIFF
--- a/examples/afl_untracer/afl-untracer.c
+++ b/examples/afl_untracer/afl-untracer.c
@@ -284,7 +284,7 @@ library_list_t *find_library(char *name) {
 // this seems to work for clang too. nice :) requires gcc 4.4+
 #pragma GCC push_options
 #pragma GCC optimize("O0")
-void        breakpoint(void) {
+void breakpoint(void) {
 
   if (debug) fprintf(stderr, "Breakpoint function \"breakpoint\" reached.\n");
 

--- a/include/xxhash.h
+++ b/include/xxhash.h
@@ -287,7 +287,7 @@ typedef uint32_t XXH32_hash_t;
   #else
     #include <limits.h>
     #if UINT_MAX == 0xFFFFFFFFUL
-typedef unsigned int  XXH32_hash_t;
+typedef unsigned int XXH32_hash_t;
     #else
       #if ULONG_MAX == 0xFFFFFFFFUL
 typedef unsigned long XXH32_hash_t;

--- a/instrumentation/split-compares-pass.so.cc
+++ b/instrumentation/split-compares-pass.so.cc
@@ -601,15 +601,12 @@ size_t SplitComparesTransform::splitFPCompares(Module &M) {
     if (op_size != op1->getType()->getPrimitiveSizeInBits()) { continue; }
 
     const unsigned int sizeInBits = op0->getType()->getPrimitiveSizeInBits();
-    const unsigned int precision =
-        sizeInBits == 32
-            ? 24
-            : sizeInBits == 64
-                  ? 53
-                  : sizeInBits == 128 ? 113
-                                      : sizeInBits == 16 ? 11
-                                                         /* sizeInBits == 80 */
-                                                         : 65;
+    const unsigned int precision = sizeInBits == 32    ? 24
+                                   : sizeInBits == 64  ? 53
+                                   : sizeInBits == 128 ? 113
+                                   : sizeInBits == 16  ? 11
+                                                      /* sizeInBits == 80 */
+                                                      : 65;
 
     const unsigned           shiftR_exponent = precision - 1;
     const unsigned long long mask_fraction =

--- a/libtokencap/libtokencap.so.c
+++ b/libtokencap/libtokencap.so.c
@@ -161,8 +161,8 @@ static void __tokencap_load_mappings(void) {
 
 #elif defined __FreeBSD__ || defined __OpenBSD__ || defined __NetBSD__
 
-  #if defined   __FreeBSD__
-  int    mib[] = {CTL_KERN, KERN_PROC, KERN_PROC_VMMAP, __tokencap_pid};
+  #if defined __FreeBSD__
+  int mib[] = {CTL_KERN, KERN_PROC, KERN_PROC_VMMAP, __tokencap_pid};
   #elif defined __OpenBSD__
   int mib[] = {CTL_KERN, KERN_PROC_VMMAP, __tokencap_pid};
   #elif defined __NetBSD__
@@ -177,7 +177,7 @@ static void __tokencap_load_mappings(void) {
 
   #if defined __FreeBSD__ || defined __NetBSD__
   len = len * 4 / 3;
-  #elif defined                      __OpenBSD__
+  #elif defined __OpenBSD__
   len -= len % sizeof(struct kinfo_vmentry);
   #endif
 
@@ -202,8 +202,8 @@ static void __tokencap_load_mappings(void) {
 
   #if defined __FreeBSD__ || defined __NetBSD__
 
-    #if defined   __FreeBSD__
-    size_t                size = region->kve_structsize;
+    #if defined __FreeBSD__
+    size_t size = region->kve_structsize;
 
     if (size == 0) break;
     #elif defined __NetBSD__

--- a/qbdi_mode/template.cpp
+++ b/qbdi_mode/template.cpp
@@ -44,7 +44,7 @@ target_func              p_target_func = NULL;
 rword                    module_base = 0;
 rword                    module_end = 0;
 static unsigned char
-               dummy[MAP_SIZE]; /* costs MAP_SIZE but saves a few instructions */
+    dummy[MAP_SIZE];         /* costs MAP_SIZE but saves a few instructions */
 unsigned char *afl_area_ptr = NULL;           /* Exported for afl_gen_trace */
 
 unsigned long afl_prev_loc = 0;


### PR DESCRIPTION
All changes are extra whitespace removed by running `make code-format`
on the previous commit.