### PR TITLE
control colorize output by an env variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ test/unittests/unit_preallocable
 test/unittests/unit_list
 test/unittests/unit_rand
 test/unittests/unit_hash
+test/unittests/unit_strip_color_codes
 examples/afl_network_proxy/afl-network-server
 examples/afl_network_proxy/afl-network-client
 examples/afl_frida/afl-frida

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,4 @@
+FROM gitpod/workspace-full
+
+RUN sudo apt-get install -y clang-format-10 libcmocka-dev && \
+    sudo rm -rf /var/cache/apt/archives/*

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: echo Hello

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -337,6 +337,7 @@ help:
 	@echo "code-format: format the code, do this before you commit and send a PR please!"
 	@echo "tests: this runs the test framework. It is more catered for the developers, but if you run into problems this helps pinpointing the problem"
 	@echo "unit: perform unit tests (based on cmocka and GNU linker)"
+	@echo "unit_clean: clean unit test compilation outputs"
 	@echo "document: creates afl-fuzz-document which will only do one run and save all manipulated inputs into out/queue/mutations"
 	@echo "help: shows these build options :-)"
 	@echo "=========================================="
@@ -435,8 +436,8 @@ afl-fuzz-document: $(COMM_HDR) include/afl-fuzz.h $(AFL_FUZZ_FILES) src/afl-comm
 test/unittests/unit_maybe_alloc.o : $(COMM_HDR) include/alloc-inl.h test/unittests/unit_maybe_alloc.c $(AFL_FUZZ_FILES)
 	@$(CC) $(CFLAGS) $(ASAN_CFLAGS) -c test/unittests/unit_maybe_alloc.c -o test/unittests/unit_maybe_alloc.o
 
-unit_maybe_alloc: test/unittests/unit_maybe_alloc.o
-	@$(CC) $(CFLAGS) -Wl,--wrap=exit -Wl,--wrap=printf test/unittests/unit_maybe_alloc.o -o test/unittests/unit_maybe_alloc $(LDFLAGS) $(ASAN_LDFLAGS) -lcmocka
+unit_maybe_alloc: test/unittests/unit_maybe_alloc.o src/afl-common.o
+	@$(CC) $(CFLAGS) -Wl,--wrap=exit -Wl,--wrap=printf $^ -o test/unittests/unit_maybe_alloc $(LDFLAGS) $(ASAN_LDFLAGS) -lcmocka
 	./test/unittests/unit_maybe_alloc
 
 test/unittests/unit_hash.o : $(COMM_HDR) include/alloc-inl.h test/unittests/unit_hash.c $(AFL_FUZZ_FILES) src/afl-performance.o
@@ -456,15 +457,15 @@ unit_rand: test/unittests/unit_rand.o src/afl-common.o src/afl-performance.o
 test/unittests/unit_list.o : $(COMM_HDR) include/list.h test/unittests/unit_list.c $(AFL_FUZZ_FILES)
 	@$(CC) $(CFLAGS) $(ASAN_CFLAGS) -c test/unittests/unit_list.c -o test/unittests/unit_list.o
 
-unit_list: test/unittests/unit_list.o
-	@$(CC) $(CFLAGS) $(ASAN_CFLAGS) -Wl,--wrap=exit -Wl,--wrap=printf test/unittests/unit_list.o -o test/unittests/unit_list  $(LDFLAGS) $(ASAN_LDFLAGS) -lcmocka
+unit_list: test/unittests/unit_list.o src/afl-common.o
+	@$(CC) $(CFLAGS) $(ASAN_CFLAGS) -Wl,--wrap=exit -Wl,--wrap=printf $^ -o test/unittests/unit_list  $(LDFLAGS) $(ASAN_LDFLAGS) -lcmocka
 	./test/unittests/unit_list
 
 test/unittests/unit_preallocable.o : $(COMM_HDR) include/alloc-inl.h test/unittests/unit_preallocable.c $(AFL_FUZZ_FILES)
 	@$(CC) $(CFLAGS) $(ASAN_CFLAGS) -c test/unittests/unit_preallocable.c -o test/unittests/unit_preallocable.o
 
-unit_preallocable: test/unittests/unit_preallocable.o
-	@$(CC) $(CFLAGS) $(ASAN_CFLAGS) -Wl,--wrap=exit -Wl,--wrap=printf test/unittests/unit_preallocable.o -o test/unittests/unit_preallocable $(LDFLAGS) $(ASAN_LDFLAGS) -lcmocka
+unit_preallocable: test/unittests/unit_preallocable.o src/afl-common.o
+	@$(CC) $(CFLAGS) $(ASAN_CFLAGS) -Wl,--wrap=exit -Wl,--wrap=printf $^ -o test/unittests/unit_preallocable $(LDFLAGS) $(ASAN_LDFLAGS) -lcmocka
 	./test/unittests/unit_preallocable
 
 test/unittests/unit_strip_color_codes.o : $(COMM_HDR) test/unittests/unit_strip_color_codes.c
@@ -480,7 +481,7 @@ unit_clean:
 
 .PHONY: unit
 ifneq "$(shell uname)" "Darwin"
-unit:	unit_maybe_alloc unit_preallocable unit_list unit_clean unit_rand unit_hash
+unit:	unit_maybe_alloc unit_preallocable unit_list unit_clean unit_rand unit_hash unit_strip_color_codes
 else
 unit:
 	@echo [-] unit tests are skipped on Darwin \(lacks GNU linker feature --wrap\)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -539,7 +539,7 @@ all_done: test_build
 .NOTPARALLEL: clean all
 
 .PHONY: clean
-clean:
+clean:	unit_clean
 	rm -f $(PROGS) libradamsa.so afl-fuzz-document afl-as as afl-g++ afl-clang afl-clang++ *.o src/*.o *~ a.out core core.[1-9][0-9]* *.stackdump .test .test1 .test2 test-instr .test-instr0 .test-instr1 afl-qemu-trace afl-gcc-fast afl-gcc-pass.so afl-g++-fast ld *.so *.8 test/unittests/*.o test/unittests/unit_maybe_alloc test/unittests/preallocable .afl-* afl-gcc afl-g++ test/unittests/unit_hash test/unittests/unit_rand
 	-$(MAKE) -f GNUmakefile.llvm clean
 	-$(MAKE) -f GNUmakefile.gcc_plugin clean

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -467,9 +467,16 @@ unit_preallocable: test/unittests/unit_preallocable.o
 	@$(CC) $(CFLAGS) $(ASAN_CFLAGS) -Wl,--wrap=exit -Wl,--wrap=printf test/unittests/unit_preallocable.o -o test/unittests/unit_preallocable $(LDFLAGS) $(ASAN_LDFLAGS) -lcmocka
 	./test/unittests/unit_preallocable
 
+test/unittests/unit_strip_color_codes.o : $(COMM_HDR) test/unittests/unit_strip_color_codes.c
+	@$(CC) $(CFLAGS) $(ASAN_CFLAGS) -c test/unittests/unit_strip_color_codes.c -o test/unittests/unit_strip_color_codes.o
+
+unit_strip_color_codes: test/unittests/unit_strip_color_codes.o src/afl-common.o
+	@$(CC) $(CFLAGS) $(ASAN_CFLAGS) -Wl,--wrap=exit -Wl,--wrap=printf $^ -o test/unittests/unit_strip_color_codes $(LDFLAGS) $(ASAN_LDFLAGS) -lcmocka
+	./test/unittests/unit_strip_color_codes
+
 .PHONY: unit_clean
 unit_clean:
-	@rm -f ./test/unittests/unit_preallocable ./test/unittests/unit_list ./test/unittests/unit_maybe_alloc test/unittests/*.o
+	@rm -f ./test/unittests/unit_strip_color_codes ./test/unittests/unit_preallocable ./test/unittests/unit_list ./test/unittests/unit_maybe_alloc test/unittests/*.o
 
 .PHONY: unit
 ifneq "$(shell uname)" "Darwin"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
+
 # American Fuzzy Lop plus plus (afl++)
 
   <img align="right" src="https://raw.githubusercontent.com/andreafioraldi/AFLplusplus-website/master/static/logo_256x256.png" alt="AFL++ Logo">
 
   ![Travis State](https://api.travis-ci.com/AFLplusplus/AFLplusplus.svg?branch=stable)
+  [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/AFLplusplus/AFLplusplus)
 
   Release Version: [2.67c](https://github.com/AFLplusplus/AFLplusplus/releases)
 

--- a/include/debug.h
+++ b/include/debug.h
@@ -171,7 +171,13 @@
 /* Just print stuff to the appropriate stream. */
 
 #ifdef MESSAGES_TO_STDOUT
-  #define SAYF(x...) printf(x)
+  #ifdef USE_COLOR
+extern u8 decolorize_console_output;
+int       color_controlled_printf(const char *fmt, ...);
+    #define SAYF(x...) color_controlled_printf(x)
+  #else
+    #define SAYF(x...) printf(x)
+  #endif
 #else
   #define SAYF(x...) fprintf(stderr, x)
 #endif                                               /* ^MESSAGES_TO_STDOUT */

--- a/include/debug.h
+++ b/include/debug.h
@@ -173,7 +173,8 @@
 #ifdef MESSAGES_TO_STDOUT
   #ifdef USE_COLOR
 extern u8 decolorize_console_output;
-int       color_controlled_printf(const char *fmt, ...);
+void      strip_color_codes(char *s);
+int       color_controlled_printf(char *fmt, ...);
     #define SAYF(x...) color_controlled_printf(x)
   #else
     #define SAYF(x...) printf(x)

--- a/include/debug.h
+++ b/include/debug.h
@@ -173,7 +173,7 @@
 #ifdef MESSAGES_TO_STDOUT
   #ifdef USE_COLOR
 extern u8 decolorize_console_output;
-void      strip_color_codes(char *s);
+void      strip_color_codes(char s[]);
 int       color_controlled_printf(char *fmt, ...);
     #define SAYF(x...) color_controlled_printf(x)
   #else

--- a/src/afl-common.c
+++ b/src/afl-common.c
@@ -918,10 +918,9 @@ s32 create_file(u8 *fn) {
   #define AFL_DECOLORIZE_CONSOLE_OUTPUT "AFL_DECOLORIZE_CONSOLE_OUTPUT"
 
 void strip_color_codes(char *s) {
-
-  // ... remove all occurrences of cXXX and bgXXX from s (in-place)
-  (void)s;
-
+    if(!*s) return;
+    char *r = s+1;
+    do { *s++ = *r++;} while(*s);
 }
 
 int color_controlled_printf(char *fmt, ...) {

--- a/src/afl-common.c
+++ b/src/afl-common.c
@@ -913,16 +913,18 @@ s32 create_file(u8 *fn) {
 #ifdef USE_COLOR
 
   #include <inttypes.h>
+  #include <stdarg.h>
 
   #define AFL_DECOLORIZE_CONSOLE_OUTPUT "AFL_DECOLORIZE_CONSOLE_OUTPUT"
 
-static strip_color_codes(char *s) {
+void strip_color_codes(char *s) {
 
   // ... remove all occurrences of cXXX and bgXXX from s (in-place)
+  (void)s;
 
 }
 
-int color_controlled_printf(const char *fmt, ...) {
+int color_controlled_printf(char *fmt, ...) {
 
   va_list args;
 
@@ -942,7 +944,7 @@ int color_controlled_printf(const char *fmt, ...) {
   if (decolorize_console_output) strip_color_codes(fmt);
   return vprintf(fmt, args);
 
-};
+}
 
 #endif
 

--- a/src/afl-common.c
+++ b/src/afl-common.c
@@ -917,7 +917,7 @@ s32 create_file(u8 *fn) {
 
   #define AFL_DECOLORIZE_CONSOLE_OUTPUT "AFL_DECOLORIZE_CONSOLE_OUTPUT"
 
-void strip_color_codes(char *s) {
+void strip_color_codes(char s[]) {
     if(!*s) return;
     char *r = s+1;
     do { *s++ = *r++;} while(*s);

--- a/src/afl-common.c
+++ b/src/afl-common.c
@@ -910,3 +910,39 @@ s32 create_file(u8 *fn) {
 
 }
 
+#ifdef USE_COLOR
+
+  #include <inttypes.h>
+
+  #define AFL_DECOLORIZE_CONSOLE_OUTPUT "AFL_DECOLORIZE_CONSOLE_OUTPUT"
+
+static strip_color_codes(char *s) {
+
+  // ... remove all occurrences of cXXX and bgXXX from s (in-place)
+
+}
+
+int color_controlled_printf(const char *fmt, ...) {
+
+  va_list args;
+
+  static u8 initialized_from_env = 0;
+  static u8 decolorize_console_output = 0;
+  if (!initialized_from_env) {
+
+    initialized_from_env = 1;
+    decolorize_console_output =
+        getenv(AFL_DECOLORIZE_CONSOLE_OUTPUT)
+            ? ((u8)strtoumax(getenv(AFL_DECOLORIZE_CONSOLE_OUTPUT), NULL, 2))
+            : 0;
+
+  }
+
+  va_start(args, fmt);
+  if (decolorize_console_output) strip_color_codes(fmt);
+  return vprintf(fmt, args);
+
+};
+
+#endif
+

--- a/test/unittests/unit_strip_color_codes.c
+++ b/test/unittests/unit_strip_color_codes.c
@@ -15,6 +15,8 @@ Test-cases for strip_color_codes function
 
 #define PAYLOAD "dummy"
 
+/* TODO: Add test with NULL ptr */
+
 static void empty_string(void **state) {
     (void) state; /* unused */
     char *sut = "";
@@ -23,13 +25,23 @@ static void empty_string(void **state) {
     assert_string_equal(sut, exp);
 }
 
-static void remove_cXXX_code(void **state) {
-    char *inp = cRED PAYLOAD cRST;
+static void remove_leading_escape(void **state) {
+    char inp[10] = "\x1b" PAYLOAD ;
     char *exp = PAYLOAD;
     (void) state; /* unused */
     printf("exp: [%s]\n", exp);
     printf("inp: [%s]\n", inp);
     strip_color_codes(inp);
+    assert_string_equal(inp, exp);
+}
+
+static void remove_leading_escape_from_literal(void **state) {
+    char inp[10] = "\x1b" PAYLOAD ;
+    char *exp = PAYLOAD;
+    (void) state; /* unused */
+    printf("exp: [%s]\n", exp);
+    printf("inp: [%s]\n", inp);
+    strip_color_codes( "\x1b" PAYLOAD );
     assert_string_equal(inp, exp);
 }
 
@@ -43,7 +55,8 @@ static void remove_cXXX_code(void **state) {
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(empty_string),
-        cmocka_unit_test(remove_cXXX_code),
+        cmocka_unit_test(remove_leading_escape),
+        cmocka_unit_test(remove_leading_escape_from_literal),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/test/unittests/unit_strip_color_codes.c
+++ b/test/unittests/unit_strip_color_codes.c
@@ -26,7 +26,7 @@ static void empty_string(void **state) {
 }
 
 static void remove_leading_escape(void **state) {
-    char inp[10] = "\x1b" PAYLOAD ;
+    char inp[] = "\x1b" PAYLOAD ;
     char *exp = PAYLOAD;
     (void) state; /* unused */
     printf("exp: [%s]\n", exp);
@@ -36,13 +36,11 @@ static void remove_leading_escape(void **state) {
 }
 
 static void remove_leading_escape_from_literal(void **state) {
-    char inp[10] = "\x1b" PAYLOAD ;
     char *exp = PAYLOAD;
     (void) state; /* unused */
     printf("exp: [%s]\n", exp);
-    printf("inp: [%s]\n", inp);
+    printf("inp: [%s]\n", "\x1b" PAYLOAD);
     strip_color_codes( "\x1b" PAYLOAD );
-    assert_string_equal(inp, exp);
 }
 
   /*

--- a/test/unittests/unit_strip_color_codes.c
+++ b/test/unittests/unit_strip_color_codes.c
@@ -4,12 +4,15 @@ Test-cases for strip_color_codes function
 
 */
 
+#include <stdio.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
 #include <cmocka.h>
 
+#define USE_COLOR
 #include "debug.h"
+
 #define PAYLOAD "dummy"
 
 static void empty_string(void **state) {
@@ -21,11 +24,13 @@ static void empty_string(void **state) {
 }
 
 static void remove_cXXX_code(void **state) {
-    (void) state; /* unused */
-    char *sut = cBLK PAYLOAD;
+    char *inp = cRED PAYLOAD cRST;
     char *exp = PAYLOAD;
-    strip_color_codes(sut);
-    assert_string_equal(sut, exp);
+    (void) state; /* unused */
+    printf("exp: [%s]\n", exp);
+    printf("inp: [%s]\n", inp);
+    strip_color_codes(inp);
+    assert_string_equal(inp, exp);
 }
 
   /*

--- a/test/unittests/unit_strip_color_codes.c
+++ b/test/unittests/unit_strip_color_codes.c
@@ -1,0 +1,44 @@
+/*
+
+Test-cases for strip_color_codes function
+
+*/
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "debug.h"
+#define PAYLOAD "dummy"
+
+static void empty_string(void **state) {
+    (void) state; /* unused */
+    char *sut = "";
+    char *exp = "";
+    strip_color_codes(sut);
+    assert_string_equal(sut, exp);
+}
+
+static void remove_cXXX_code(void **state) {
+    (void) state; /* unused */
+    char *sut = cBLK PAYLOAD;
+    char *exp = PAYLOAD;
+    strip_color_codes(sut);
+    assert_string_equal(sut, exp);
+}
+
+  /*
+  Parameterize to test if strip_color_codes...
+    removes cBLK, cRED, cGRN, cBRN, cBLU, cMGN, cCYA, cLGR, cGRA, cLRD, cLGN, cYEL, cLBL, cPIN, cLCY, cBRI, cRST
+    removes bgBLK, bgRED, bgGRN, bgBRN, bgBLU, bgMGN, bgCYA, bgLGR, bgGRA, bgLRD, bgLGN, bgYEL, bgLBL, bgPIN, bgLCY, bgBRI,
+    does not remove "\x1b[H", "\x1b[2J", "\x1b[0K", "\x1b[?25l", "\x1b[?25h"
+  */
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(empty_string),
+        cmocka_unit_test(remove_cXXX_code),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Proposed solution for [AFLplusplus#485](https://github.com/AFLplusplus/AFLplusplus/issues/485)

Currently all logging messages eventually resolve to the SAYF macro. The format-string lieral is constructed at compile-time with expanded color-codes or no color-codes based on USE_COLOR flag. 

To achieve runtime control of color codes the idea is to use an env var (AFL_DECOLORIZE_CONSOLE_OUTPUT) to control output of color codes. When AFL was compiled with USE_COLOR, then it checks the presence and value of this variable and when it is set to 1, it strips the color-codes from the format strings.
